### PR TITLE
Fix FSF postal address

### DIFF
--- a/btrfs/__init__.py
+++ b/btrfs/__init__.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this program; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 021110-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 from btrfs.ctree import FileSystem  # noqa
 from btrfs.ctree import (  # noqa

--- a/btrfs/ctree.py
+++ b/btrfs/ctree.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this program; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 021110-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 from __future__ import division, print_function, absolute_import, unicode_literals
 import copy

--- a/btrfs/ioctl.py
+++ b/btrfs/ioctl.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this program; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 021110-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 from __future__ import division, print_function, absolute_import, unicode_literals
 from collections import namedtuple

--- a/btrfs/utils.py
+++ b/btrfs/utils.py
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this program; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 021110-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 from __future__ import division, print_function, absolute_import, unicode_literals
 import btrfs.ctree

--- a/examples/munin/plugins/btrfs_usage
+++ b/examples/munin/plugins/btrfs_usage
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this program; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 021110-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 
 from __future__ import print_function

--- a/examples/nagios/plugins/check_btrfs
+++ b/examples/nagios/plugins/check_btrfs
@@ -13,8 +13,8 @@
 #
 # You should have received a copy of the GNU General Public
 # License along with this program; if not, write to the
-# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-# Boston, MA 021110-1307, USA.
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301 USA
 
 from __future__ import division, print_function, absolute_import, unicode_literals
 import argparse


### PR DESCRIPTION
Hi, I'm creating a RPM package for Fedora [1] and I see that the FSF postal address is wrong in the license headers.

Here is a patch to fix that.

Thank you!

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1356083
