### PR TITLE
examples/show_block_groups: properly format output

### DIFF
--- a/examples/show_block_groups.py
+++ b/examples/show_block_groups.py
@@ -9,4 +9,6 @@ if len(sys.argv) < 2:
 
 with btrfs.FileSystem(sys.argv[1]) as fs:
     for chunk in fs.chunks():
-        print(fs.block_group(chunk.vaddr, chunk.length))
+        bg = fs.block_group(chunk.vaddr, chunk.length)
+        print("block group offset {0:>13d} len {1:>10d} used {2:>10d} usage {3:>.2f} flags {4}"
+            .format(bg.vaddr, bg.length, bg.used, bg.used_pct/100, bg.flags_str))


### PR DESCRIPTION
Block group flag names are variable-length, so reorder the fields and properly format
numerical values. This makes the output almost identical to btrfs-debugfs and
sort(1)-able by column.
A small step towards replacing the old ~~perl~~python-based btrfs-debugfs with something based
on python-btrfs.
