### PR TITLE
man: Use neutral language about units

### DIFF
--- a/man/btrfs-space-calculator.1
+++ b/man/btrfs-space-calculator.1
@@ -39,9 +39,9 @@ An example:
       Device 2: 0.00B
       Device 3: 0.00B
 
-Note that most physical disk vendors specify their sizes in GB or TB for
-deceptive marketing reasons, while partitions created in your average partition
-table or with lvm2 etc... are usually using MiB, GiB and TiB.
+Note that most physical disk vendors specify their sizes in GB or TB, while
+partitions created in your average partition table or with lvm2 etc... are
+usually using MiB, GiB and TiB.
 
 .SH OPTIONS
 .TP


### PR DESCRIPTION
Sorry this is kind of trivial, but it just irks me as an engineer when people complain about drive companies using standard engineering units and claiming they're being "intentionally deceptive", just because Microsoft uses the same units in a non-standard way.  They measured this way [since before Microsoft even existed](https://en.wikipedia.org/wiki/Timeline_of_binary_prefixes#1974), and I [don't believe anyone ever intended it to be deceptive or did it for marketing reasons](https://paulhutch.blog/2007/11/05/seagate-settles-bogus-class-action/).  It's better to have neutral language in documentation.
