### PR TITLE
setup.py: Add scripts to the script keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,13 @@ setup(
     url='https://github.com/knorrie/python-btrfs',
     download_url='https://github.com/knorrie/python-btrfs/tarball/v{}'.format(version),
     keywords=['btrfs', 'filesystem'],
+    scripts=[
+        'bin/btrfs-balance-least-used',
+        'bin/btrfs-orphan-cleaner-progress',
+        'bin/btrfs-search-metadata',
+        'bin/btrfs-space-calculator',
+        'bin/btrfs-usage-report'
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This results in the scripts being automatically installed into the `bin`
directory of your python distribution, which ultimately lands in the
`PATH` variable, making these easier accessible.

Tested via the NixOS packaging:

```
❯ nix-build -A python3Packages.btrfs
these derivations will be built:
  /nix/store/vml1gkdnn9r7ilqq8q9qdnl2sbs0nzd6-python3.8-btrfs-12.drv
building '/nix/store/vml1gkdnn9r7ilqq8q9qdnl2sbs0nzd6-python3.8-btrfs-12.drv' on 'ssh://hexa@phoibe.cysec.de'...
copying 1 paths...
copying path '/nix/store/5lxzkxxdq0sysfw7f9lf5haalmwwpcwh-source' to 'ssh://hexa@phoibe.cysec.de'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing setuptools-build-hook
Using setuptoolsBuildPhase
Using setuptoolsShellHook
Sourcing pip-install-hook
Using pipInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing setuptools-check-hook
Using setuptoolsCheckPhase
unpacking sources
unpacking source archive /nix/store/5lxzkxxdq0sysfw7f9lf5haalmwwpcwh-source
source root is source
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file source/setup.py
patching sources
configuring
no configure script, doing nothing
building
Executing setuptoolsBuildPhase
running bdist_wheel
running build
running build_py
creating build
creating build/lib
creating build/lib/btrfs
copying btrfs/version.py -> build/lib/btrfs
copying btrfs/fs_usage.py -> build/lib/btrfs
copying btrfs/__init__.py -> build/lib/btrfs
copying btrfs/utils.py -> build/lib/btrfs
copying btrfs/ctree.py -> build/lib/btrfs
copying btrfs/crc32c.py -> build/lib/btrfs
copying btrfs/volumes.py -> build/lib/btrfs
copying btrfs/ioctl.py -> build/lib/btrfs
copying btrfs/free_space_tree.py -> build/lib/btrfs
running build_scripts
creating build/scripts-3.8
copying and adjusting bin/btrfs-balance-least-used -> build/scripts-3.8
copying and adjusting bin/btrfs-orphan-cleaner-progress -> build/scripts-3.8
copying and adjusting bin/btrfs-search-metadata -> build/scripts-3.8
copying and adjusting bin/btrfs-space-calculator -> build/scripts-3.8
copying and adjusting bin/btrfs-usage-report -> build/scripts-3.8
changing mode of build/scripts-3.8/btrfs-balance-least-used from 644 to 755
changing mode of build/scripts-3.8/btrfs-orphan-cleaner-progress from 644 to 755
changing mode of build/scripts-3.8/btrfs-search-metadata from 644 to 755
changing mode of build/scripts-3.8/btrfs-space-calculator from 644 to 755
changing mode of build/scripts-3.8/btrfs-usage-report from 644 to 755
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/version.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/fs_usage.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/__init__.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/utils.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/ctree.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/crc32c.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/volumes.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/ioctl.py -> build/bdist.linux-x86_64/wheel/btrfs
copying build/lib/btrfs/free_space_tree.py -> build/bdist.linux-x86_64/wheel/btrfs
running install_egg_info
running egg_info
creating btrfs.egg-info
writing btrfs.egg-info/PKG-INFO
writing dependency_links to btrfs.egg-info/dependency_links.txt
writing top-level names to btrfs.egg-info/top_level.txt
writing manifest file 'btrfs.egg-info/SOURCES.txt'
reading manifest file 'btrfs.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'btrfs.egg-info/SOURCES.txt'
Copying btrfs.egg-info to build/bdist.linux-x86_64/wheel/btrfs-12-py3.8.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/btrfs-12.data
creating build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts
copying build/scripts-3.8/btrfs-space-calculator -> build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts
copying build/scripts-3.8/btrfs-orphan-cleaner-progress -> build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts
copying build/scripts-3.8/btrfs-search-metadata -> build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts
copying build/scripts-3.8/btrfs-balance-least-used -> build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts
copying build/scripts-3.8/btrfs-usage-report -> build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts
changing mode of build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts/btrfs-space-calculator to 755
changing mode of build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts/btrfs-orphan-cleaner-progress to 755
changing mode of build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts/btrfs-search-metadata to 755
changing mode of build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts/btrfs-balance-least-used to 755
changing mode of build/bdist.linux-x86_64/wheel/btrfs-12.data/scripts/btrfs-usage-report to 755
adding license file "COPYING.LESSER" (matched pattern "COPYING*")
creating build/bdist.linux-x86_64/wheel/btrfs-12.dist-info/WHEEL
creating 'dist/btrfs-12-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'btrfs/__init__.py'
adding 'btrfs/crc32c.py'
adding 'btrfs/ctree.py'
adding 'btrfs/free_space_tree.py'
adding 'btrfs/fs_usage.py'
adding 'btrfs/ioctl.py'
adding 'btrfs/utils.py'
adding 'btrfs/version.py'
adding 'btrfs/volumes.py'
adding 'btrfs-12.data/scripts/btrfs-balance-least-used'
adding 'btrfs-12.data/scripts/btrfs-orphan-cleaner-progress'
adding 'btrfs-12.data/scripts/btrfs-search-metadata'
adding 'btrfs-12.data/scripts/btrfs-space-calculator'
adding 'btrfs-12.data/scripts/btrfs-usage-report'
adding 'btrfs-12.dist-info/COPYING.LESSER'
adding 'btrfs-12.dist-info/METADATA'
adding 'btrfs-12.dist-info/WHEEL'
adding 'btrfs-12.dist-info/top_level.txt'
adding 'btrfs-12.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Finished executing setuptoolsBuildPhase
installing
Executing pipInstallPhase
/build/source/dist /build/source
Processing ./btrfs-12-py3-none-any.whl
Installing collected packages: btrfs
Successfully installed btrfs-12
/build/source
Finished executing pipInstallPhase
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12
strip is /nix/store/5xyjd2qiily84lcv2w2grmwsb8r1hqpr-binutils-2.35.1/bin/strip
stripping (with command strip and flags -S) in /nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/lib  /nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/bin
patching script interpreter paths in /nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12
checking for references to /build/ in /nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12...
Rewriting #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/bin/python3.8 to #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9
wrapping `/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/bin/btrfs-space-calculator'...
Rewriting #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/bin/python3.8 to #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9
wrapping `/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/bin/btrfs-orphan-cleaner-progress'...
Rewriting #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/bin/python3.8 to #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9
wrapping `/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/bin/btrfs-search-metadata'...
Rewriting #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/bin/python3.8 to #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9
wrapping `/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/bin/btrfs-balance-least-used'...
Rewriting #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9/bin/python3.8 to #!/nix/store/q6gfck5czr67090pwm53xrdyhpg6bx67-python3-3.8.9
wrapping `/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12/bin/btrfs-usage-report'...
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
running install tests
no Makefile or custom installCheckPhase, doing nothing
pythonCatchConflictsPhase
pythonRemoveBinBytecodePhase
pythonImportsCheckPhase
Executing pythonImportsCheckPhase
setuptoolsCheckPhase
Executing setuptoolsCheckPhase
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing btrfs.egg-info/PKG-INFO
writing dependency_links to btrfs.egg-info/dependency_links.txt
writing top-level names to btrfs.egg-info/top_level.txt
reading manifest file 'btrfs.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'btrfs.egg-info/SOURCES.txt'
running build_ext

----------------------------------------------------------------------
Ran 0 tests in 0.000s

OK
Finished executing setuptoolsCheckPhase
copying 1 paths...
copying path '/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12' from 'ssh://hexa@phoibe.cysec.de'...
/nix/store/rdamlcb1gpsmkb0qnh0igy8fdcnmjmgn-python3.8-btrfs-12
❯ ls result/bin
btrfs-balance-least-used  btrfs-orphan-cleaner-progress  btrfs-search-metadata  btrfs-space-calculator  btrfs-usage-report
```