### PR TITLE
examples/show_file_csum: Fix vaddr computation

### DIFF
--- a/examples/show_file_csum.py
+++ b/examples/show_file_csum.py
@@ -90,11 +90,11 @@ wraprint("At offset {} in the file, it's using {} bytes of data which we can fin
          "inside a data extent at vaddr {}.".format(
              extent.logical_offset, extent.num_bytes, extent.offset, extent.disk_bytenr))
 
-vaddr = extent.disk_bytenr + extent.logical_offset
+vaddr = extent.disk_bytenr + extent.offset
 
 wraprint("Now, we first look up the checksum value for one block ({} bytes) "
          "of data at vaddr {} ({} + {}).".format(
-             fs.sectorsize, vaddr, extent.disk_bytenr, extent.logical_offset))
+             fs.sectorsize, vaddr, extent.disk_bytenr, extent.offset))
 wraprint("If we're lucky, the checksum tree has a key at {}. "
          "If not, we have to try searching back a bit to find the csum object that "
          "holds information about our data block. Searching back is done in a very clumsy "


### PR DESCRIPTION
I wrote some code based on this example, and I realized that the computed block address isn't always correct.

https://github.com/knorrie/python-btrfs/blob/4aa37fc7f5b8133d30abf3ba398fa44d1b03c7ea/examples/show_file_csum.py#L89-L97

The printed message on line 89 describes the meaning of the two offsets fairly well.

For the purposes of this example, the vaddr as computed above is often coincidentally correct, because `offset == logical_offset == 0`. But the checksums produced by the example disagree when the offsets aren't equal, unless the expression is changed to `extent.disk_bytenr + extent.offset`.