### PR TITLE
bin: add blockgroup report

### DIFF
--- a/bin/btrfs-blockgroup-report
+++ b/bin/btrfs-blockgroup-report
@@ -40,12 +40,18 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--usage',
+        '-u',
         action="store_true",
         help="Print device blockgroup usage",
     )
     parser.add_argument(
         'mountpoint',
         help="Btrfs filesystem mountpoint",
+    )
+    parser.add_argument(
+        'device',
+        nargs='*',
+        help="Only use specific devices (default include all)",
     )
     return parser.parse_args()
 
@@ -60,9 +66,17 @@ def safe_get_block_group(t):
 
 def report_usage(args):
     with btrfs.FileSystem(args.mountpoint) as fs:
+        fs_chunks = list(fs.chunks())
+
         devices = fs.devices()
         devids = [d.devid for d in devices]
-        fs_chunks = list(fs.chunks())
+        if args.device:
+            dev_infos = [fs.dev_info(id) for id in devids]
+            selected_devids = []
+            for dev in dev_infos:
+                if any(d in (dev.path, dev.devid) for d in args.device):
+                    selected_devids.append(dev.devid)
+            devids = selected_devids
 
         print(args.mountpoint, '\t', fs.usage().virtual_used_str, '\t', len(fs_chunks), 'fs chunks')
         for devid in devids:
@@ -103,9 +117,9 @@ def report_usage(args):
                     stats = chunk_stats[data_flag]
 
                     print('\t', data_flag)
-                    print('\t' * 2, 'Blockgroups at least partially on disk:', stats['count'])
-                    print('\t' * 2, 'Data-device dependance:', pretty_size(stats['size_used']))
-                    print('\t' * 2, 'Approx. blockgroup percentage packed:')
+                    print('\t' * 2, 'Data-device dependence:', pretty_size(stats['size_used']))
+                    print('\t' * 2, 'Blockgroups:', stats['count'])
+                    print('\t' * 2, 'Blockgroup packing:')
 
                     grouped_stats = {}
                     for percent in stats['percent_used']:
@@ -115,13 +129,9 @@ def report_usage(args):
                         else:
                             grouped_stats[group] = 1
 
-                    min_count = min(count for _group, count in grouped_stats.items())
                     max_count = max(count for _group, count in grouped_stats.items())
                     for group, count in sorted(grouped_stats.items()):
-                        try:
-                            scaled_count = int(60 * (count - min_count) / (max_count - min_count))
-                        except ZeroDivisionError:
-                            scaled_count = 1
+                        scaled_count = int(60 * count / max_count) if max_count > 60 else count
                         print(
                             '\t' * 2,
                             f'  {str(group).rjust(3)}% packed',

--- a/bin/btrfs-blockgroup-report
+++ b/bin/btrfs-blockgroup-report
@@ -1,0 +1,160 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2018 Hans van Kranenburg <hans@knorrie.org>
+#             , 2023 Jacob Chapman <github.com/chapmanjacobd>
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import argparse
+import errno
+import sys
+from itertools import repeat
+from multiprocessing import Pool
+
+import btrfs
+from btrfs.utils import pretty_size
+
+
+class Bork(Exception):
+    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--usage',
+        action="store_true",
+        help="Print device blockgroup usage",
+    )
+    parser.add_argument(
+        'mountpoint',
+        help="Btrfs filesystem mountpoint",
+    )
+    return parser.parse_args()
+
+
+def safe_get_block_group(t):
+    fs, vaddr = t
+    try:
+        return fs.block_group(vaddr)
+    except IndexError:
+        return None
+
+
+def report_usage(args):
+    with btrfs.FileSystem(args.mountpoint) as fs:
+        devices = fs.devices()
+        devids = [d.devid for d in devices]
+        fs_chunks = list(fs.chunks())
+
+        print(args.mountpoint, '\t', fs.usage().virtual_used_str, '\t', len(fs_chunks), 'fs chunks')
+        for devid in devids:
+            dev_info = fs.dev_info(devid)
+            dev_vaddrs = [d.vaddr for d in fs.dev_extents(devid)]
+            print(
+                dev_info.path,
+                '\t',
+                dev_info.bytes_used_str,
+                '\t',
+                len(dev_vaddrs),
+                'device blockgroup extents',
+                "({:.0%})".format(len(dev_vaddrs) / len(fs_chunks)),
+            )
+
+        if args.usage:
+            print('\nBlockgroup usage:')
+            for devid in devids:
+                print(fs.dev_info(devid).path)
+                dev_vaddrs = [d.vaddr for d in fs.dev_extents(devid)]
+
+                chunk_stats = {}
+                with Pool() as pool:
+                    results = pool.map(safe_get_block_group, zip(repeat(fs), dev_vaddrs))
+                    for bg in [r for r in results if r is not None]:
+                        if bg.flags_str in chunk_stats:
+                            chunk_stats[bg.flags_str]['count'] += 1
+                            chunk_stats[bg.flags_str]['size_used'] += bg.used
+                            chunk_stats[bg.flags_str]['percent_used'].append(bg.used_pct)
+                        else:
+                            chunk_stats[bg.flags_str] = {
+                                'count': 1,
+                                'size_used': bg.used,
+                                'percent_used': [bg.used_pct],
+                            }
+
+                for data_flag in sorted(chunk_stats):
+                    stats = chunk_stats[data_flag]
+
+                    print('\t', data_flag)
+                    print('\t' * 2, 'Blockgroups at least partially on disk:', stats['count'])
+                    print('\t' * 2, 'Data-device dependance:', pretty_size(stats['size_used']))
+                    print('\t' * 2, 'Approx. blockgroup percentage packed:')
+
+                    grouped_stats = {}
+                    for percent in stats['percent_used']:
+                        group = (percent // 10) * 10
+                        if group in grouped_stats:
+                            grouped_stats[group] += 1
+                        else:
+                            grouped_stats[group] = 1
+
+                    min_count = min(count for _group, count in grouped_stats.items())
+                    max_count = max(count for _group, count in grouped_stats.items())
+                    for group, count in sorted(grouped_stats.items()):
+                        try:
+                            scaled_count = int(60 * (count - min_count) / (max_count - min_count))
+                        except ZeroDivisionError:
+                            scaled_count = 1
+                        print(
+                            '\t' * 2,
+                            f'  {str(group).rjust(3)}% packed',
+                            '*' * max(scaled_count, 1),
+                            f"({count})",
+                        )
+                    print('\n')
+
+
+def main():
+    args = parse_args()
+    try:
+        report_usage(args)
+    except OSError as e:
+        if e.errno == errno.EPERM:
+            raise Bork(
+                "Insufficient permissions to use the btrfs kernel API.\n"
+                "Hint: Try running the script as root user.".format(e)
+            )
+        elif e.errno == errno.ENOTTY:
+            raise Bork("Unable to retrieve data. Hint: Not a mounted btrfs file system?")
+        raise
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Exiting...")
+        sys.exit(130)  # 128 + SIGINT
+    except Bork as e:
+        print("Error: {0}".format(e), file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
I don't know how useful you will find this to be. Feel free to close if you think it does not add value. I only made this because I wanted to learn more about btrfs

When running device remove, the difference is pretty extreme compared to `btrfs device usage` (2.70TiB vs 10.75TiB). So it could be useful in that situation, to get a better understanding of the `btrfs device remove` process which people complain about being slow but in reality it seems to be pretty fast; `de usage` is just not showing the whole picture:

```
sudo bin/btrfs-blockgroup-report /mnt/do /dev/sdd -u                                                                                                                                                   
/mnt/do          9.03TiB         39391 fs chunks                                                                                                                                                                                  
/dev/sdd         10.75TiB        11005 device blockgroup extents (28%)                                                                                                                                                            
                                                                                                                                                                                                                                  
Blockgroup usage:                                                                                                                                                                                                                 
/dev/sdd                                                                                                                                                                                                                          
         DATA                                                                                                                                                                                                                     
                 Data-device dependence: 2.70TiB                                                                                                                                                                                  
                 Blockgroups: 10992                                                                                                                                                                                               
                 Blockgroup packing:                                                                                                                                                                                              
                     0% packed ************************************************************ (4401)                                                                                                                                
                    10% packed ********************* (1578)                                                                                                                                                                       
                    20% packed ***************** (1247)                                                                                                                                                                           
                    30% packed ************* (980)                                                                                                                                                                                
                    40% packed ********** (776)                                                                                                                                                                                   
                    50% packed ******* (583)                                                                                                                                                                                      
                    60% packed ****** (458)                                                                                                                                                                                       
                    70% packed **** (335)                                                                                                                                                                                         
                    80% packed *** (265)                                                                                                                                                                                          
                    90% packed *** (290)                                                                                                                                                                                          
                   100% packed * (79)                                                                                                                                                                                             


         METADATA|RAID1
                 Data-device dependence: 5.28GiB
                 Blockgroups: 13
                 Blockgroup packing:
                    30% packed ******* (7)
                    40% packed **** (4)
                    50% packed ** (2)

$ sudo btrfs de usage /mnt/do
/dev/sda, ID: 1
   Device size:            16.37TiB
   Device slack:              0.00B
   Data,single:            15.63TiB
   Metadata,RAID1:         32.00GiB
   System,RAID1:           32.00MiB
   Unallocated:           722.91GiB

/dev/sdc, ID: 2
   Device size:            12.73TiB
   Device slack:              0.00B
   Data,single:            12.06TiB
   Metadata,RAID1:         19.00GiB
   System,RAID1:           32.00MiB
   Unallocated:           665.97GiB

/dev/sdd, ID: 4
   Device size:            12.73TiB
   Device slack:           12.73TiB
   Data,single:            10.73TiB
   Metadata,RAID1:         13.00GiB
   Unallocated:           -10.75TiB
```

The default mode is pretty quick and it only prints number of device extents which can be useful for planning the order of `device remove` commands; but for more thorough device introspection I added a `--usage` flag to iterate over all the device extents

```
$ sudo env PYTHONBREAKPOINT=ipdb.set_trace /home/xk/github/o/python-btrfs/bin/btrfs-blockgroup-report /mnt/do/
/mnt/do/ 	26.35TiB 	54048 fs chunks
/dev/sda 	16.11TiB 	54107 chunk extents (100%)
/dev/sdc 	12.47TiB 	37608 chunk extents (70%)
/dev/sdd 	12.47TiB 	24841 chunk extents (46%)
/dev/sdh 	11.79TiB 	12069 chunk extents (22%)
```

This is what the output looks like with the `--usage` flag (this part is slow, takes between 20 seconds to 5 mins to run):

```sh
$ sudo env PYTHONBREAKPOINT=ipdb.set_trace /home/xk/github/o/python-btrfs/bin/btrfs-blockgroup-report --usage /mnt/do/
/mnt/do/ 	26.35TiB 	54048 fs chunks
/dev/sda 	16.11TiB 	54107 chunk extents (100%)
/dev/sdc 	12.47TiB 	37608 chunk extents (70%)
/dev/sdd 	12.47TiB 	24841 chunk extents (46%)
/dev/sdh 	11.79TiB 	12069 chunk extents (22%)

Blockgroup usage:
/dev/sda
	DATA
		Chunks at least partially on disk: 53989
		Data-device dependance: 26.3TiB
		Approx. chunk percentage used:
		    0% packed ************************************************************ (6524 chunks)
		   10% packed ********************************************* (5368 chunks)
		   20% packed ********************************************* (5352 chunks)
		   30% packed ****************************************** (5042 chunks)
		   40% packed *************************************** (4795 chunks)
		   50% packed **************************************** (4884 chunks)
		   60% packed **************************************** (4943 chunks)
		   70% packed ************************************* (4700 chunks)
		   80% packed ************************************ (4606 chunks)
		   90% packed ******************************************************** (6202 chunks)
		  100% packed * (1573 chunks)

	METADATA|RAID1
		Chunks at least partially on disk: 116
		Data-device dependance: 68.3GiB
		Approx. chunk percentage used:
		   30% packed * (2 chunks)
		   40% packed *********** (14 chunks)
		   50% packed ***************************** (32 chunks)
		   60% packed ************************************************************ (64 chunks)
		   70% packed * (4 chunks)

	SYSTEM|RAID1
		Chunks at least partially on disk: 2
		Data-device dependance: 12.8MiB
		Approx. chunk percentage used:
		   20% packed * (2 chunks)


/dev/sdc
	DATA
		Chunks at least partially on disk: 37549
		Data-device dependance: 18.1TiB
		Approx. chunk percentage used:
		    0% packed ************************************************************ (4654 chunks)
		   10% packed ********************************************* (3753 chunks)
		   20% packed ********************************************* (3760 chunks)
		   30% packed ***************************************** (3560 chunks)
		   40% packed ************************************** (3377 chunks)
		   50% packed ************************************** (3390 chunks)
		   60% packed *************************************** (3447 chunks)
		   70% packed ************************************ (3237 chunks)
		   80% packed ********************************** (3107 chunks)
		   90% packed **************************************************** (4215 chunks)
		  100% packed * (1049 chunks)

	METADATA|RAID1
		Chunks at least partially on disk: 58
		Data-device dependance: 34.1GiB
		Approx. chunk percentage used:
		   30% packed * (1 chunks)
		   40% packed *********** (7 chunks)
		   50% packed ***************************** (16 chunks)
		   60% packed ************************************************************ (32 chunks)
		   70% packed * (2 chunks)

	SYSTEM|RAID1
		Chunks at least partially on disk: 1
		Data-device dependance: 6.4MiB
		Approx. chunk percentage used:
		   20% packed * (1 chunks)


/dev/sdd
	DATA
		Chunks at least partially on disk: 24782
		Data-device dependance: 11.8TiB
		Approx. chunk percentage used:
		    0% packed ************************************************************ (3163 chunks)
		   10% packed ********************************************** (2580 chunks)
		   20% packed ********************************************* (2535 chunks)
		   30% packed **************************************** (2333 chunks)
		   40% packed ************************************** (2247 chunks)
		   50% packed ************************************* (2215 chunks)
		   60% packed ************************************** (2243 chunks)
		   70% packed ************************************ (2158 chunks)
		   80% packed ********************************* (2037 chunks)
		   90% packed ************************************************ (2674 chunks)
		  100% packed * (597 chunks)

	METADATA|RAID1
		Chunks at least partially on disk: 58
		Data-device dependance: 34.1GiB
		Approx. chunk percentage used:
		   30% packed * (1 chunks)
		   40% packed *********** (7 chunks)
		   50% packed ***************************** (16 chunks)
		   60% packed ************************************************************ (32 chunks)
		   70% packed * (2 chunks)

	SYSTEM|RAID1
		Chunks at least partially on disk: 1
		Data-device dependance: 6.4MiB
		Approx. chunk percentage used:
		   20% packed * (1 chunks)


/dev/sdh
	DATA
		Chunks at least partially on disk: 12010
		Data-device dependance: 5.4TiB
		Approx. chunk percentage used:
		    0% packed ************************************************************ (1658 chunks)
		   10% packed ************************************************ (1386 chunks)
		   20% packed ******************************************* (1266 chunks)
		   30% packed **************************************** (1192 chunks)
		   40% packed *********************************** (1064 chunks)
		   50% packed ************************************ (1073 chunks)
		   60% packed ************************************ (1074 chunks)
		   70% packed ********************************** (1045 chunks)
		   80% packed ***************************** (909 chunks)
		   90% packed *************************************** (1149 chunks)
		  100% packed * (194 chunks)

	METADATA|RAID1
		Chunks at least partially on disk: 58
		Data-device dependance: 34.1GiB
		Approx. chunk percentage used:
		   30% packed * (1 chunks)
		   40% packed *********** (7 chunks)
		   50% packed ***************************** (16 chunks)
		   60% packed ************************************************************ (32 chunks)
		   70% packed * (2 chunks)

	SYSTEM|RAID1
		Chunks at least partially on disk: 1
		Data-device dependance: 6.4MiB
		Approx. chunk percentage used:
		   20% packed * (1 chunks)
```


You can compare this to the output of the fs usage-report:

```
sudo btrfs-usage-report /mnt/do
Btrfs usage report for /mnt/do
Filesystem ID: 8da156d7-abd4-4c84-a2f0-8c17f43eb60c
Mixed groups: False

Total physical space usage:
| 
| Total filesystem size: 56.21TiB
| Allocated bytes: 52.86TiB
| Allocatable bytes remaining: 3.35TiB

Target profiles:
|
| type         profile     
| ----         -------     
| System       RAID1       
| Metadata     RAID1       
| Data         single      

Estimated virtual space left for use:
|
| type         free        
| ----         ----        
| Data         29.66TiB    
| MetaData     31.73GiB    

Virtual space usage by block group type:
|
| type                total         used
| ----                -----         ----
| Data             52.75TiB     26.42TiB
| System           32.00MiB      6.39MiB
| Metadata         58.00GiB     34.27GiB

Allocated raw disk bytes by chunk type.
|
| flags               allocated         used    parity *)
| -----               ---------         ----    ---------
| DATA                 52.75TiB     26.42TiB        0.00B
| SYSTEM|RAID1         64.00MiB     12.78MiB        0.00B
| METADATA|RAID1      116.00GiB     68.54GiB        0.00B
|
| *) Parity is a reserved part of the allocated bytes, limiting the
|    amount that can be used for data or metadata.

Allocated bytes per device:
|
| devid      total size    allocated path
| -----      ----------    --------- ----
| 1            16.37TiB     16.11TiB /dev/sda
| 2            12.73TiB     12.47TiB /dev/sdc
| 4            12.73TiB     12.47TiB /dev/sdd
| 5            14.37TiB     11.81TiB /dev/sdh

Allocated bytes per device, split up by chunk type.
|
| Device ID: 1
| | flags               allocated    parity *)
| | -----               ---------    ---------
| | DATA                 16.05TiB        0.00B
| | METADATA|RAID1       58.00GiB        0.00B
| | SYSTEM|RAID1         32.00MiB        0.00B
|
| Device ID: 2
| | flags               allocated    parity *)
| | -----               ---------    ---------
| | DATA                 12.47TiB        0.00B
|
| Device ID: 4
| | flags               allocated    parity *)
| | -----               ---------    ---------
| | DATA                 12.47TiB        0.00B
|
| Device ID: 5
| | flags               allocated    parity *)
| | -----               ---------    ---------
| | DATA                 11.75TiB        0.00B
| | METADATA|RAID1       58.00GiB        0.00B
| | SYSTEM|RAID1         32.00MiB        0.00B
|
| *) Parity is a reserved part of the allocated bytes, limiting the
|    amount that can be used for data or metadata.

Unallocatable raw disk space:
|
| Reclaimable (by using balance): 0.00B
| Not reclaimable (because of different disk sizes): 0.00B

Unallocatable bytes per device, given current target profiles:
|
| devid         soft *)     hard **) reclaimable ***)
| -----         -------     -------- ----------------
| 1               0.00B        0.00B            0.00B
| 2               0.00B        0.00B            0.00B
| 4               0.00B        0.00B            0.00B
| 5               0.00B        0.00B            0.00B
|
|   *) Because allocations in the filesystem are unbalanced.
|  **) Because of having different sizes of devices attached.
| ***) Amount of 'soft' unallocatable space that can be reclaimed,
|      before hitting the 'hard' limit.
```

I'm not sure why there are slightly more device blockgroups than fs chunks:

```
sudo env PYTHONBREAKPOINT=ipdb.set_trace /home/xk/github/o/python-btrfs/bin/btrfs-blockgroup-report --usage /mnt/d2/
/mnt/d2/ 	10.66TiB 	10929 fs chunks
/dev/sde1 	10.69TiB 	10947 device blockgroup extents (100%)

Blockgroup usage:
/dev/sde1
	DATA
		Blockgroups at least partially on disk: 10911
		Data-device dependance: 10.65TiB
		Approx. blockgroup percentage packed:
		    0% packed * (1)
		   40% packed * (1)
		   70% packed * (7)
		   80% packed * (20)
		   90% packed * (141)
		  100% packed ************************************************************ (10741)


	METADATA|DUP
		Blockgroups at least partially on disk: 34
		Data-device dependance: 32.11GiB
		Approx. blockgroup percentage packed:
		    0% packed * (2)
		  100% packed ************************************************************ (32)


	SYSTEM|DUP
		Blockgroups at least partially on disk: 2
		Data-device dependance: 2.38MiB
		Approx. blockgroup percentage packed:
		    0% packed * (2)
```