### PR TITLE
add support for block-group-tree

### DIFF
--- a/btrfs/ioctl.py
+++ b/btrfs/ioctl.py
@@ -1325,10 +1325,14 @@ def _compat_flags_str(flags):
 
 FEATURE_COMPAT_RO_FREE_SPACE_TREE = 1 << 0
 FEATURE_COMPAT_RO_FREE_SPACE_TREE_VALID = 1 << 1
+FEATURE_COMPAT_RO_VERITY = 1 << 2
+FEATURE_COMPAT_RO_BLOCK_GROUP_TREE = 1 << 3
 
 _feature_compat_ro_str_map = {
     FEATURE_COMPAT_RO_FREE_SPACE_TREE: 'free_space_tree',
     FEATURE_COMPAT_RO_FREE_SPACE_TREE_VALID: 'free_space_tree_valid',
+    FEATURE_COMPAT_RO_VERITY: 'verity',
+    FEATURE_COMPAT_RO_BLOCK_GROUP_TREE: 'block_group_tree',
 }
 
 
@@ -1383,6 +1387,8 @@ class FeatureFlags(object):
 
     - FEATURE_COMPAT_RO_FREE_SPACE_TREE
     - FEATURE_COMPAT_RO_FREE_SPACE_TREE_VALID
+    - FEATURE_COMPAT_RO_VERITY
+    - FEATURE_COMPAT_RO_BLOCK_GROUP_TREE
 
     Known incompat_flags (available as attribute of this module) are:
 


### PR DESCRIPTION
[btrfs from 6.1 above](https://btrfs.readthedocs.io/en/latest/Kernel-by-version.html#dec-2022) got the support for a new [compact_ro feature "block-group-tree"](https://github.com/torvalds/linux/blob/39cd87c4eb2b893354f3b850f916353f2658ae6f/include/uapi/linux/btrfs.h#L315) which seperate out block group items from the extent tree into a dedicated tree. Using [`btrfstune` can convert](https://btrfs.readthedocs.io/en/latest/btrfstune.html#options) existing filesystems to leverage this new feature (or going back).

Due to excellent design in `python-btrfs`'s implementation and APIs, we don't need to change much to support this new feature.  `FileSystem.block_group` is already seperated from `FileSystem.extents`. We can read the feature flags and then `search_v2` on the new tree instead of the extent tree.

This should cover part of the fix for https://github.com/knorrie/btrfs-heatmap/issues/14
(with the coloring scheme for the heatmap undecided)


## Tests

I use btrfs-heatmap to test this change.

Firstly make a btrfs.img with some data in it. Without `block-group-tree` feature enabled:
```shell-session
$ sudo btrfs inspect-internal dump-super test/btrfs.img
superblock: bytenr=65536, device=test/btrfs.img
---------------------------------------------------------
csum_type               0 (crc32c)
csum_size               4
csum                    0xa98838ea [match]
bytenr                  65536
flags                   0x1
                        ( WRITTEN )
magic                   _BHRfS_M [match]
fsid                    ec8d207c-b64a-4d80-8fa4-f09634210c5c
metadata_uuid           00000000-0000-0000-0000-000000000000
label
generation              23
root                    30621696
sys_array_size          129
chunk_root_generation   15
root_level              0
chunk_root              22069248
chunk_root_level        0
log_root                0
log_root_transid (deprecated)   0
log_root_level          0
total_bytes             8589934592
bytes_used              3381899264
sectorsize              4096
nodesize                16384
leafsize (deprecated)   16384
stripesize              4096
root_dir                6
num_devices             1
compat_flags            0x0
compat_ro_flags         0x3
                        ( FREE_SPACE_TREE |
                          FREE_SPACE_TREE_VALID )
incompat_flags          0x361
                        ( MIXED_BACKREF |
                          BIG_METADATA |
                          EXTENDED_IREF |
                          SKINNY_METADATA |
                          NO_HOLES )
cache_generation        0
uuid_tree_generation    21
dev_item.uuid           c41ac422-544c-4447-9bf0-251d3fe793e0
dev_item.fsid           ec8d207c-b64a-4d80-8fa4-f09634210c5c [match]
dev_item.type           0
dev_item.total_bytes    8589934592
dev_item.bytes_used     4924112896
dev_item.io_align       4096
dev_item.io_width       4096
dev_item.sector_size    4096
dev_item.devid          1
dev_item.dev_group      0
dev_item.seek_speed     0
dev_item.bandwidth      0
dev_item.generation     0

$ btrfstune --convert-from-block-group-tree test/btrfs.img
$ sudo btrfs-heatmap test/mp --verbose
scope device 1
grid curve hilbert order 4 size 10 height 16 width 16 total_bytes 8589934592 bytes_per_pixel 33554432.0
dev_extent devid 1 paddr 13631488 length 8388608 pend 22020095 type DATA used_pct 16.16
dev_extent devid 1 paddr 22020096 length 8388608 pend 30408703 type SYSTEM|DUP used_pct 0.20
dev_extent devid 1 paddr 30408704 length 8388608 pend 38797311 type SYSTEM|DUP used_pct 0.20
dev_extent devid 1 paddr 38797312 length 268435456 pend 307232767 type METADATA|DUP used_pct 1.39
dev_extent devid 1 paddr 307232768 length 268435456 pend 575668223 type METADATA|DUP used_pct 1.39
dev_extent devid 1 paddr 575668224 length 872415232 pend 1448083455 type DATA used_pct 98.79
dev_extent devid 1 paddr 1448083456 length 872415232 pend 2320498687 type DATA used_pct 15.85
dev_extent devid 1 paddr 2320498688 length 872415232 pend 3192913919 type DATA used_pct 98.88
dev_extent devid 1 paddr 3192913920 length 872415232 pend 4065329151 type DATA used_pct 90.19
dev_extent devid 1 paddr 4065329152 length 872415232 pend 4937744383 type DATA used_pct 83.35
pngfile fsid_ec8d207c-b64a-4d80-8fa4-f09634210c5c_at_1711979929.png
```

Then convert it to `block-group-tree` to show the problem with the current released version:
```
$ sudo umount test/mp
$ btrfstune --convert-to-block-group-tree test/btrfs.img
Converted the filesystem to block group tree feature
$ sudo mount test/btrfs.img test/mp
$ sudo btrfs inspect-internal dump-super test/btrfs.img
superblock: bytenr=65536, device=test/btrfs.img
---------------------------------------------------------
csum_type               0 (crc32c)
csum_size               4
csum                    0xe27ef6c6 [match]
bytenr                  65536
flags                   0x1
                        ( WRITTEN )
magic                   _BHRfS_M [match]
fsid                    ec8d207c-b64a-4d80-8fa4-f09634210c5c
metadata_uuid           00000000-0000-0000-0000-000000000000
label
generation              27
root                    30687232
sys_array_size          129
chunk_root_generation   15
root_level              0
chunk_root              22069248
chunk_root_level        0
log_root                0
log_root_transid (deprecated)   0
log_root_level          0
total_bytes             8589934592
bytes_used              3381915648
sectorsize              4096
nodesize                16384
leafsize (deprecated)   16384
stripesize              4096
root_dir                6
num_devices             1
compat_flags            0x0
compat_ro_flags         0xb
                        ( FREE_SPACE_TREE |
                          FREE_SPACE_TREE_VALID |
                          BLOCK_GROUP_TREE )
incompat_flags          0x361
                        ( MIXED_BACKREF |
                          BIG_METADATA |
                          EXTENDED_IREF |
                          SKINNY_METADATA |
                          NO_HOLES )
cache_generation        0
uuid_tree_generation    25
dev_item.uuid           c41ac422-544c-4447-9bf0-251d3fe793e0
dev_item.fsid           ec8d207c-b64a-4d80-8fa4-f09634210c5c [match]
dev_item.type           0
dev_item.total_bytes    8589934592
dev_item.bytes_used     4924112896
dev_item.io_align       4096
dev_item.io_width       4096
dev_item.sector_size    4096
dev_item.devid          1
dev_item.dev_group      0
dev_item.seek_speed     0
dev_item.bandwidth      0
dev_item.generation     0

$ sudo btrfs-heatmap test/mp --verbose
scope device 1
grid curve hilbert order 4 size 10 height 16 width 16 total_bytes 8589934592 bytes_per_pixel 33554432.0
pngfile fsid_ec8d207c-b64a-4d80-8fa4-f09634210c5c_at_1711980040.png
```

As we can see it cannot read the block groups with the current version.

Then use the fixed branch:
```
$ sudo env PYTHONPATH=$(pwd) btrfs-heatmap test/mp --verbose
scope device 1
grid curve hilbert order 4 size 10 height 16 width 16 total_bytes 8589934592 bytes_per_pixel 33554432.0
dev_extent devid 1 paddr 13631488 length 8388608 pend 22020095 type DATA used_pct 16.16
dev_extent devid 1 paddr 22020096 length 8388608 pend 30408703 type SYSTEM|DUP used_pct 0.20
dev_extent devid 1 paddr 30408704 length 8388608 pend 38797311 type SYSTEM|DUP used_pct 0.20
dev_extent devid 1 paddr 38797312 length 268435456 pend 307232767 type METADATA|DUP used_pct 1.40
dev_extent devid 1 paddr 307232768 length 268435456 pend 575668223 type METADATA|DUP used_pct 1.40
dev_extent devid 1 paddr 575668224 length 872415232 pend 1448083455 type DATA used_pct 98.79
dev_extent devid 1 paddr 1448083456 length 872415232 pend 2320498687 type DATA used_pct 15.85
dev_extent devid 1 paddr 2320498688 length 872415232 pend 3192913919 type DATA used_pct 98.88
dev_extent devid 1 paddr 3192913920 length 872415232 pend 4065329151 type DATA used_pct 90.19
dev_extent devid 1 paddr 4065329152 length 872415232 pend 4937744383 type DATA used_pct 83.35
pngfile fsid_ec8d207c-b64a-4d80-8fa4-f09634210c5c_at_1711980145.png
```

It can now show the block groups.