### PR TITLE
Btrfs balance exclude devid

### DIFF
--- a/bin/btrfs-balance-exclude-devid
+++ b/bin/btrfs-balance-exclude-devid
@@ -12,6 +12,7 @@ class Bork(Exception):
 def load_block_groups(fs, devid):
     block_groups = []
     balanced = 0
+    skipped = 0
     #print("Loading all block group objects ...", flush=True)
     for chunk in fs.chunks():
         if not (chunk.type & btrfs.BLOCK_GROUP_DATA):
@@ -33,10 +34,11 @@ def load_block_groups(fs, devid):
                 args = btrfs.ioctl.BalanceArgs(vstart=chunk.vaddr, vend=chunk.vaddr+1)
                 progress = btrfs.ioctl.balance_v2(fs.fd, data_args=args)
             else:
-                print ("skipping {} with stripe devids = {}".format(chunk, devid_list))
-
+                skipped += 1
+                print ("skipping {} with stripe devids = {} skipped_count = {}".format(chunk, devid_list, skipped))
         except IndexError:
             continue
+    print ("Finished balanced_count = {} skipped_count = {} ".format(balanced, skipped))
     heapq.heapify(block_groups)
     print(" found {}".format(len(block_groups)))
     return block_groups

--- a/bin/btrfs-balance-exclude-devid
+++ b/bin/btrfs-balance-exclude-devid
@@ -1,0 +1,99 @@
+#!/usr/bin/python3
+import argparse
+import btrfs
+import errno
+import heapq
+import sys
+import time
+
+class Bork(Exception):
+    pass
+
+def load_block_groups(fs, devid):
+    block_groups = []
+    balanced = 0
+    #print("Loading all block group objects ...", flush=True)
+    for chunk in fs.chunks():
+        if not (chunk.type & btrfs.BLOCK_GROUP_DATA):
+            continue
+        try:
+            block_group = fs.block_group(chunk.vaddr, chunk.length)
+            block_groups.append((block_group.used_pct, block_group))
+            #print (chunk)
+            #print (chunk.stripes)
+            skip = False
+            devid_list = []
+            for stripe in chunk.stripes:
+                devid_list.append(stripe.devid)
+                if stripe.devid == devid:
+                    skip = True
+            if not skip:
+                balanced += 1
+                print ("balancing {} with stripe devids = {} balanced_count = {}".format(chunk, devid_list, balanced))
+                args = btrfs.ioctl.BalanceArgs(vstart=chunk.vaddr, vend=chunk.vaddr+1)
+                progress = btrfs.ioctl.balance_v2(fs.fd, data_args=args)
+            else:
+                print ("skipping {} with stripe devids = {}".format(chunk, devid_list))
+
+        except IndexError:
+            continue
+    heapq.heapify(block_groups)
+    print(" found {}".format(len(block_groups)))
+    return block_groups
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d',
+        '--devid',
+        required=True,
+        type=int,
+        help="devid to exclude from balance - ie balance only block groups that don't have a stripe on this device",
+    )
+    parser.add_argument(
+        'mountpoint',
+        help="Btrfs filesystem mountpoint",
+    )
+    return parser.parse_args()
+
+def permission_check(fs):
+    """This is a simple canary function that explodes if the user does not have
+    enough permissions to use the search ioctl.
+    """
+    fs.top_level()
+
+
+def main():
+    args = parse_args()
+    devid = args.devid
+    path = args.mountpoint
+    try:
+        with btrfs.FileSystem(path) as fs:
+            permission_check(fs)
+            block_groups = load_block_groups(fs, devid)
+            if len(block_groups) == 0:
+                print("No block groups found, akinda weird")
+                return
+#            while len(block_groups) > 0:
+#                balance_if_needed(fs, block_groups, devid)
+    except OSError as e:
+        if e.errno == errno.EPERM:
+            raise Bork("Insufficient permissions to use the btrfs kernel API.\n"
+                       "Hint: Try running the script as root user.".format(e))
+        elif e.errno == errno.ENOTTY:
+            raise Bork("Unable to retrieve data. Hint: Not a mounted btrfs file system?")
+        raise
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("Exiting...")
+        sys.exit(130)  # 128 + SIGINT
+    except Bork as e:
+        print("Error: {0}".format(e), file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(e)
+        sys.exit(1)

--- a/man/btrfs-balance-exclude-devid.1
+++ b/man/btrfs-balance-exclude-devid.1
@@ -1,0 +1,74 @@
+.TH BTRFS\-BALANCE\-EXCLUDE\-DEVID 1 "2025" "" "Btrfs Balance Excluding Devid"
+.nh
+.ad l
+
+.SH "NAME"
+btrfs\-balance\-exclude\-devid \- Balance block groups that don't have a stripe
+on the excluded devid.
+
+.SH SYNOPSIS
+.B btrfs\-balance\-exclude\-devid
+[\fIargs\fR]
+.IR mountpoint
+
+.SH DESCRIPTION
+Suppose you had a unbalanced btrfs 4 drive raid 1 filesystem with one drive
+having a lot of unallocated space.  You'd want to do a balance targeting 
+block groups that don't already have a stripe on the devid 
+with the most Unallocated space.  This program allows you to do just that,
+a balance excluding any block groups that have a stripe on the 
+excluded devid.
+
+Typically you'd want to exclude the devid with the most unallocated space.
+
+# btrfs device usage -g /mnt/backupdrive
+/dev/dm-10, ID: 1
+   Device size:          11175.98GiB
+   Device slack:            0.00GiB
+   Data,RAID1:           9993.95GiB
+   Metadata,RAID1:         35.00GiB
+   System,RAID1:            0.03GiB
+   Unallocated:          1147.00GiB <- Want to do a balance reduces this
+
+/dev/dm-7, ID: 2
+   Device size:          5589.01GiB
+   Device slack:            0.00GiB
+   Data,RAID1:           5297.95GiB
+   Metadata,RAID1:         14.00GiB
+   System,RAID1:            0.03GiB
+   Unallocated:           277.03GiB
+
+/dev/dm-8, ID: 3
+   Device size:          5589.01GiB
+   Device slack:            0.00GiB
+   Data,RAID1:           5296.00GiB
+   Metadata,RAID1:         16.00GiB
+   Unallocated:           277.01GiB
+
+/dev/dm-9, ID: 4
+   Device size:          1863.00GiB
+   Device slack:            0.00GiB
+   Data,RAID1:           1858.00GiB
+   Metadata,RAID1:          5.00GiB
+   Unallocated:             0.00GiB
+
+
+Example output:
+$ sudo ./btrfs-balance-exclude-devid -d 1 /mnt/backupdrive
+balancing chunk vaddr 10301576577024 type DATA|RAID1 length 1.00GiB 
+                 num_stripes 2 with stripe devids = [2, 3] balanced_count = 1
+balancing chunk vaddr 10302650318848 type DATA|RAID1 length 1.00GiB 
+                 num_stripes 2 with stripe devids = [2, 3] balanced_count = 2
+balancing chunk vaddr 10303724060672 type DATA|RAID1 length 1.00GiB 
+                 num_stripes 2 with stripe devids = [2, 3] balanced_count = 3
+[...]
+
+.SH OPTIONS
+.TP
+.BR \-d ", " \-\-devid
+Show the built\-in help message and exit.
+
+.SH "SEE ALSO"
+This program is an example of what can be done using the python-btrfs library.
+
+Source and documentation on github: https://github.com/knorrie/python-btrfs


### PR DESCRIPTION
Suppose you had a unbalanced btrfs 4 drive raid 1 filesystem with one drive
having a lot of unallocated space.  You'd want to do a balance targeting 
block groups that don't already have a stripe on the devid 
with the most Unallocated space.  This program allows you to do just that,
a balance excluding any block groups that have a stripe on the 
excluded devid.

Typically you'd want to exclude the devid with the most unallocated space.

# btrfs device usage -g /mnt/backupdrive
/dev/dm-10, ID: 1
   Device size:          11175.98GiB
   Device slack:            0.00GiB
   Data,RAID1:           9993.95GiB
   Metadata,RAID1:         35.00GiB
   System,RAID1:            0.03GiB
   Unallocated:          1147.00GiB <- Want to do a balance reduces this

/dev/dm-7, ID: 2
   Device size:          5589.01GiB
   Device slack:            0.00GiB
   Data,RAID1:           5297.95GiB
   Metadata,RAID1:         14.00GiB
   System,RAID1:            0.03GiB
   Unallocated:           277.03GiB

/dev/dm-8, ID: 3
   Device size:          5589.01GiB
   Device slack:            0.00GiB
   Data,RAID1:           5296.00GiB
   Metadata,RAID1:         16.00GiB
   Unallocated:           277.01GiB

/dev/dm-9, ID: 4
   Device size:          1863.00GiB
   Device slack:            0.00GiB
   Data,RAID1:           1858.00GiB
   Metadata,RAID1:          5.00GiB
   Unallocated:             0.00GiB


Example output:
$ sudo ./btrfs-balance-exclude-devid -d 1 /mnt/backupdrive
balancing chunk vaddr 10301576577024 type DATA|RAID1 length 1.00GiB 
                 num_stripes 2 with stripe devids = [2, 3] balanced_count = 1
balancing chunk vaddr 10302650318848 type DATA|RAID1 length 1.00GiB 
                 num_stripes 2 with stripe devids = [2, 3] balanced_count = 2
balancing chunk vaddr 10303724060672 type DATA|RAID1 length 1.00GiB 
                 num_stripes 2 with stripe devids = [2, 3] balanced_count = 3
[...]
